### PR TITLE
fix: Windows compatibility improvements

### DIFF
--- a/scripts/extract-audio.sh
+++ b/scripts/extract-audio.sh
@@ -5,6 +5,9 @@
 
 set -euo pipefail
 
+# Add ffmpeg path for Windows compatibility (put ffmpeg binaries in ~/bin/)
+export PATH="$HOME/bin:$PATH"
+
 INPUT="${1:?Usage: extract-audio.sh <input_video> <output_dir> [whisper_model]}"
 OUTPUT_DIR="${2:?Specify output directory}"
 MODEL="${3:-base}"  # tiny|base|small|medium|large

--- a/scripts/extract-frames.sh
+++ b/scripts/extract-frames.sh
@@ -8,6 +8,9 @@
 
 set -euo pipefail
 
+# Add ffmpeg path for Windows compatibility (put ffmpeg binaries in ~/bin/)
+export PATH="$HOME/bin:$PATH"
+
 INPUT="${1:?Usage: extract-frames.sh <input_video> <output_dir> <fps_rate> [max_frames] [stream_index] [grid_layout] [start_time] [end_time]}"
 OUTPUT_DIR="${2:?Specify output directory}"
 FPS="${3:?Specify fps rate (e.g., 2, 1, 0.1, 0.05)}"
@@ -63,7 +66,8 @@ fi
 # Get video info from the correct stream
 DURATION=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$INPUT" 2>/dev/null)
 RESOLUTION=$(ffprobe -v error -select_streams v:${STREAM_INDEX} -show_entries stream=width,height -of csv=p=0 "$INPUT" 2>/dev/null || echo "unknown")
-TOTAL_FRAMES=$(echo "$DURATION * $FPS" | bc -l 2>/dev/null | cut -d. -f1)
+# Use python3 instead of bc for Windows compatibility
+TOTAL_FRAMES=$(python3 -c "print(int($DURATION * $FPS))" 2>/dev/null)
 
 echo "=== Video Frame Extraction ==="
 echo "Input: $INPUT"

--- a/scripts/video-info.sh
+++ b/scripts/video-info.sh
@@ -6,6 +6,9 @@
 
 set -euo pipefail
 
+# Add ffmpeg path for Windows compatibility (put ffmpeg binaries in ~/bin/)
+export PATH="$HOME/bin:$PATH"
+
 INPUT="${1:?Usage: video-info.sh <input_video> [fps_override] [start_time] [end_time]}"
 FPS_OVERRIDE="${2:-}"      # e.g., "5" for 5fps, "0.2" for 1/5sec
 START_TIME="${3:-}"        # e.g., "00:00:10" or "10"
@@ -89,10 +92,11 @@ if [[ -n "$START_TIME" && -n "$END_TIME" ]]; then
     # Convert HH:MM:SS or seconds to seconds
     start_sec=$(echo "$START_TIME" | awk -F: '{if(NF==3) print $1*3600+$2*60+$3; else if(NF==2) print $1*60+$2; else print $1}')
     end_sec=$(echo "$END_TIME" | awk -F: '{if(NF==3) print $1*3600+$2*60+$3; else if(NF==2) print $1*60+$2; else print $1}')
-    EFFECTIVE_DURATION=$(echo "$end_sec - $start_sec" | bc -l 2>/dev/null)
+    # Use python3 instead of bc for Windows compatibility
+    EFFECTIVE_DURATION=$(python3 -c "print($end_sec - $start_sec)" 2>/dev/null)
 elif [[ -n "$START_TIME" ]]; then
     start_sec=$(echo "$START_TIME" | awk -F: '{if(NF==3) print $1*3600+$2*60+$3; else if(NF==2) print $1*60+$2; else print $1}')
-    EFFECTIVE_DURATION=$(echo "$DURATION - $start_sec" | bc -l 2>/dev/null)
+    EFFECTIVE_DURATION=$(python3 -c "print($DURATION - $start_sec)" 2>/dev/null)
 elif [[ -n "$END_TIME" ]]; then
     end_sec=$(echo "$END_TIME" | awk -F: '{if(NF==3) print $1*3600+$2*60+$3; else if(NF==2) print $1*60+$2; else print $1}')
     EFFECTIVE_DURATION="$end_sec"
@@ -131,8 +135,8 @@ if [[ -n "$FPS_OVERRIDE" ]]; then
     DESCRIPTION="Custom: ${FPS_RATE} frames/sec (user override)"
 fi
 
-# Calculate expected frames
-EXPECTED_FRAMES=$(echo "$EFFECTIVE_DURATION * $FPS_RATE" | bc -l 2>/dev/null | cut -d. -f1)
+# Calculate expected frames (use python3 instead of bc for Windows compatibility)
+EXPECTED_FRAMES=$(python3 -c "print(int($EFFECTIVE_DURATION * $FPS_RATE))" 2>/dev/null)
 
 # Cap at 200 frames to avoid excessive extraction
 MAX_FRAMES=0


### PR DESCRIPTION
## Summary
- Replace `bc` with `python3` for floating-point calculations (bc not available on Windows Git Bash)
- Add `PATH` export for `~/bin` to allow custom ffmpeg location on Windows
- Users on Windows can now place ffmpeg/ffprobe binaries in `~/bin/` directory

## Problem
On Windows with Git Bash:
1. `bc` command is not available, causing scripts to fail
2. ffmpeg/ffprobe may not be in system PATH

## Solution
1. Use `python3 -c "print(...)"` instead of `echo ... | bc -l` for calculations
2. Add `export PATH="$HOME/bin:$PATH"` at the top of each script

## Cross-platform Compatibility
- **macOS/Linux**: No impact - `python3` is already available (used for JSON parsing)
- **Windows**: Fixes compatibility issues

## Testing
Tested on Windows 11 with Git Bash environment.

## Files Changed
- `scripts/video-info.sh` - 3 `bc` calls replaced with python3
- `scripts/extract-frames.sh` - 1 `bc` call replaced with python3  
- `scripts/extract-audio.sh` - Added PATH export