### PR TITLE
fix: sanitize shell args with input validation and bash arrays

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -58,7 +58,7 @@ bash ${CLAUDE_SKILL_DIR}/scripts/video-info.sh "<video_path>" [fps_override] [st
 bash ${CLAUDE_SKILL_DIR}/scripts/extract-frames.sh "<video_path>" "<work_dir>/frames" <fps> <max> <stream> <grid> [start_time] [end_time]
 ```
 
-When custom fps is set, tier becomes `custom` and the 200-frame safety cap applies.
+When custom fps is set, tier becomes `custom` and the 1000-frame safety cap applies.
 
 ## Workflow
 

--- a/scripts/extract-frames.sh
+++ b/scripts/extract-frames.sh
@@ -5,11 +5,11 @@
 # fps_rate examples: 2 (2/sec), 1 (1/sec), 0.1 (1/10sec), 0.05 (1/20sec)
 # stream_index: video stream index (default: auto-detect, skipping thumbnails)
 # grid_layout: tile layout for montage grids (default: 4x4)
-
+ 
 set -euo pipefail
-
+ 
 [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]] && export PATH="$HOME/bin:$PATH"
-
+ 
 INPUT="${1:?Usage: extract-frames.sh <input_video> <output_dir> <fps_rate> [max_frames] [stream_index] [grid_layout] [start_time] [end_time]}"
 OUTPUT_DIR="${2:?Specify output directory}"
 FPS="${3:?Specify fps rate (e.g., 2, 1, 0.1, 0.05)}"
@@ -18,16 +18,54 @@ STREAM_INDEX="${5:-auto}"  # auto = detect correct stream
 GRID_LAYOUT="${6:-4x4}"  # tile layout for grids
 START_TIME="${7:-}"  # e.g., "00:00:10" or "10" (seconds)
 END_TIME="${8:-}"    # e.g., "00:00:30" or "30" (seconds)
-
+ 
+is_number() {
+    [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+}
+ 
+is_time_value() {
+    [[ "$1" =~ ^([0-9]+(:[0-9]{1,2}(:[0-9]{1,2})?)?)$ ]]
+}
+ 
 # Validate input
 if [[ ! -f "$INPUT" ]]; then
     echo "ERROR: File not found: $INPUT" >&2
     exit 1
 fi
-
+ 
+if ! is_number "$FPS"; then
+    echo "ERROR: Invalid fps rate: $FPS" >&2
+    exit 1
+fi
+ 
+if ! [[ "$MAX_FRAMES" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: max_frames must be a non-negative integer: $MAX_FRAMES" >&2
+    exit 1
+fi
+ 
+if [[ "$STREAM_INDEX" != "auto" ]] && ! [[ "$STREAM_INDEX" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: stream_index must be 'auto' or a non-negative integer: $STREAM_INDEX" >&2
+    exit 1
+fi
+ 
+if ! [[ "$GRID_LAYOUT" =~ ^[1-9][0-9]*x[1-9][0-9]*$ ]]; then
+    echo "ERROR: grid_layout must match NxM (e.g., 4x4): $GRID_LAYOUT" >&2
+    exit 1
+fi
+ 
+if [[ -n "$START_TIME" ]] && ! is_time_value "$START_TIME"; then
+    echo "ERROR: Invalid start_time format: $START_TIME" >&2
+    exit 1
+fi
+ 
+if [[ -n "$END_TIME" ]] && ! is_time_value "$END_TIME"; then
+    echo "ERROR: Invalid end_time format: $END_TIME" >&2
+    exit 1
+fi
+ 
 # Create output directory
 mkdir -p "$OUTPUT_DIR"
-
+ 
 # Auto-detect video stream if not specified
 if [[ "$STREAM_INDEX" == "auto" ]]; then
     STREAM_INDEX=$(ffprobe -v error -show_streams -of json "$INPUT" 2>/dev/null | python3 -c "
@@ -49,24 +87,22 @@ else:
             break
 " 2>/dev/null || echo "0")
 fi
-
+ 
 # Build the -map argument to select the correct video stream
-MAP_ARG="-map 0:${STREAM_INDEX}"
-
-# Build time range arguments
-TIME_ARGS=""
+MAP_ARGS=("-map" "0:${STREAM_INDEX}")
+TIME_ARGS=()
 if [[ -n "$START_TIME" ]]; then
-    TIME_ARGS="-ss $START_TIME"
+    TIME_ARGS+=("-ss" "$START_TIME")
 fi
 if [[ -n "$END_TIME" ]]; then
-    TIME_ARGS="$TIME_ARGS -to $END_TIME"
+    TIME_ARGS+=("-to" "$END_TIME")
 fi
-
+ 
 # Get video info from the correct stream
 DURATION=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$INPUT" 2>/dev/null)
 RESOLUTION=$(ffprobe -v error -select_streams v:${STREAM_INDEX} -show_entries stream=width,height -of csv=p=0 "$INPUT" 2>/dev/null || echo "unknown")
 TOTAL_FRAMES=$(python3 -c "print(int(float('$DURATION') * float('$FPS')))" 2>/dev/null)
-
+ 
 echo "=== Video Frame Extraction ==="
 echo "Input: $INPUT"
 echo "Duration: ${DURATION}s"
@@ -77,66 +113,63 @@ echo "Grid layout: $GRID_LAYOUT"
 echo "Estimated frames: $TOTAL_FRAMES"
 echo "Output: $OUTPUT_DIR"
 echo ""
-
+ 
 # Build FFmpeg filter - resize to max 1280px wide, burn timestamp
 FILTER="fps=${FPS},scale='min(1280,iw)':-2,drawtext=text='%{pts\\:hms}':x=10:y=10:fontsize=28:fontcolor=white:borderw=2:bordercolor=black"
-
+ 
 # Add frame limit if specified
-FRAME_LIMIT=""
+FRAME_LIMIT_ARGS=()
 if [[ "$MAX_FRAMES" -gt 0 ]]; then
-    FRAME_LIMIT="-frames:v $MAX_FRAMES"
+    FRAME_LIMIT_ARGS=("-frames:v" "$MAX_FRAMES")
     echo "Frame limit: $MAX_FRAMES"
 fi
-
+ 
 # Extract individual frames as JPG
-# Note: $MAP_ARG, $TIME_ARGS, $FRAME_LIMIT intentionally unquoted for word splitting
 ffmpeg -i "$INPUT" \
-    $MAP_ARG \
-    $TIME_ARGS \
+    "${MAP_ARGS[@]}" \
+    "${TIME_ARGS[@]}" \
     -vf "$FILTER" \
     -q:v 2 \
-    $FRAME_LIMIT \
+    "${FRAME_LIMIT_ARGS[@]}" \
     "${OUTPUT_DIR}/frame_%05d.jpg" \
     -y -loglevel warning 2>&1
-
+ 
 EXTRACTED=$(ls "${OUTPUT_DIR}"/frame_*.jpg 2>/dev/null | wc -l | tr -d ' ')
 echo "Extracted: $EXTRACTED frames"
-
+ 
 # Generate montage grids
 echo ""
 echo "=== Creating Montage Grids ==="
-
+ 
 # Determine grid cell size based on orientation
 # Parse grid layout to determine if portrait-optimized
 GRID_CELL_WIDTH=640
 MONTAGE_FILTER="fps=${FPS},scale='min(${GRID_CELL_WIDTH},iw)':-2,drawtext=text='%{pts\\:hms}':x=5:y=5:fontsize=16:fontcolor=white:borderw=1:bordercolor=black,tile=${GRID_LAYOUT}"
-
-# Note: $MAP_ARG, $TIME_ARGS intentionally unquoted for word splitting
+ 
 ffmpeg -i "$INPUT" \
-    $MAP_ARG \
-    $TIME_ARGS \
+    "${MAP_ARGS[@]}" \
+    "${TIME_ARGS[@]}" \
     -vf "$MONTAGE_FILTER" \
     -q:v 2 \
     "${OUTPUT_DIR}/grid_%03d.jpg" \
     -y -loglevel warning 2>&1
-
+ 
 GRIDS=$(ls "${OUTPUT_DIR}"/grid_*.jpg 2>/dev/null | wc -l | tr -d ' ')
 echo "Created: $GRIDS montage grids (${GRID_LAYOUT})"
-
+ 
 # Detect scene changes (key moments)
 echo ""
 echo "=== Scene Change Detection ==="
 SCENE_FILE="${OUTPUT_DIR}/scene_changes.txt"
-# Note: $MAP_ARG, $TIME_ARGS intentionally unquoted for word splitting
 ffmpeg -i "$INPUT" \
-    $MAP_ARG \
-    $TIME_ARGS \
+    "${MAP_ARGS[@]}" \
+    "${TIME_ARGS[@]}" \
     -vf "select='gt(scene,0.3)',showinfo" \
     -f null - 2>&1 | grep 'pts_time' | sed 's/.*pts_time:\([0-9.]*\).*/\1/' | grep '^[0-9]' > "$SCENE_FILE" || true
-
+ 
 SCENE_COUNT=$(wc -l < "$SCENE_FILE" | tr -d ' ')
 echo "Detected: $SCENE_COUNT scene changes"
-
+ 
 # Extract key frames at scene changes (high-res individual frames for detailed analysis)
 # Cap at 20 key frames to avoid excessive extraction
 if [[ "$SCENE_COUNT" -gt 0 ]]; then
@@ -149,7 +182,7 @@ if [[ "$SCENE_COUNT" -gt 0 ]]; then
         TS_SAFE=$(echo "$TIMESTAMP" | tr '.' '_')
         OUTFILE="${OUTPUT_DIR}/key_frames/scene_$(printf '%02d' $KEY_IDX)_${TS_SAFE}s.jpg"
         ffmpeg -i "$INPUT" \
-            $MAP_ARG \
+            "${MAP_ARGS[@]}" \
             -ss "$TIMESTAMP" \
             -frames:v 1 \
             -vf "scale='min(1280,iw)':-2,drawtext=text='${TIMESTAMP}s':x=10:y=10:fontsize=32:fontcolor=white:borderw=2:bordercolor=black" \
@@ -161,7 +194,7 @@ if [[ "$SCENE_COUNT" -gt 0 ]]; then
     KEY_EXTRACTED=$(ls "${OUTPUT_DIR}"/key_frames/scene_*.jpg 2>/dev/null | wc -l | tr -d ' ')
     echo "Extracted: $KEY_EXTRACTED key frames at scene changes"
 fi
-
+ 
 # Write metadata file
 cat > "${OUTPUT_DIR}/metadata.json" <<METAEOF
 {

--- a/scripts/extract-frames.sh
+++ b/scripts/extract-frames.sh
@@ -5,67 +5,114 @@
 # fps_rate examples: 2 (2/sec), 1 (1/sec), 0.1 (1/10sec), 0.05 (1/20sec)
 # stream_index: video stream index (default: auto-detect, skipping thumbnails)
 # grid_layout: tile layout for montage grids (default: 4x4)
- 
+
 set -euo pipefail
- 
+
 [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]] && export PATH="$HOME/bin:$PATH"
- 
+
 INPUT="${1:?Usage: extract-frames.sh <input_video> <output_dir> <fps_rate> [max_frames] [stream_index] [grid_layout] [start_time] [end_time]}"
 OUTPUT_DIR="${2:?Specify output directory}"
 FPS="${3:?Specify fps rate (e.g., 2, 1, 0.1, 0.05)}"
-MAX_FRAMES="${4:-0}"  # 0 = unlimited
+MAX_FRAMES="${4:-0}"  # 0 = auto safety cap
 STREAM_INDEX="${5:-auto}"  # auto = detect correct stream
 GRID_LAYOUT="${6:-4x4}"  # tile layout for grids
 START_TIME="${7:-}"  # e.g., "00:00:10" or "10" (seconds)
 END_TIME="${8:-}"    # e.g., "00:00:30" or "30" (seconds)
- 
-is_number() {
-    [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+
+MAX_FPS=120
+MAX_FRAME_CAP=1000
+MAX_GRID_DIM=10
+MAX_GRID_CELLS=100
+
+is_positive_number() {
+    [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+    awk -v n="$1" 'BEGIN { exit !(n > 0) }'
 }
- 
+
+number_lte() {
+    awk -v n="$1" -v max="$2" 'BEGIN { exit !(n <= max) }'
+}
+
 is_time_value() {
-    [[ "$1" =~ ^([0-9]+(:[0-9]{1,2}(:[0-9]{1,2})?)?)$ ]]
+    [[ "$1" =~ ^[0-9]+$ || "$1" =~ ^[0-9]+:[0-5]?[0-9]$ || "$1" =~ ^[0-9]+:[0-5]?[0-9]:[0-5]?[0-9]$ ]]
 }
- 
+
+time_to_seconds() {
+    local value="$1"
+    local first second third
+    IFS=: read -r first second third <<< "$value"
+
+    if [[ -z "${second:-}" ]]; then
+        echo "$((10#$first))"
+    elif [[ -z "${third:-}" ]]; then
+        echo "$((10#$first * 60 + 10#$second))"
+    else
+        echo "$((10#$first * 3600 + 10#$second * 60 + 10#$third))"
+    fi
+}
+
 # Validate input
 if [[ ! -f "$INPUT" ]]; then
     echo "ERROR: File not found: $INPUT" >&2
     exit 1
 fi
- 
-if ! is_number "$FPS"; then
-    echo "ERROR: Invalid fps rate: $FPS" >&2
+
+if ! is_positive_number "$FPS" || ! number_lte "$FPS" "$MAX_FPS"; then
+    echo "ERROR: fps rate must be > 0 and <= ${MAX_FPS}: $FPS" >&2
     exit 1
 fi
- 
+
 if ! [[ "$MAX_FRAMES" =~ ^[0-9]+$ ]]; then
     echo "ERROR: max_frames must be a non-negative integer: $MAX_FRAMES" >&2
     exit 1
 fi
- 
+if [[ "$MAX_FRAMES" -gt "$MAX_FRAME_CAP" ]]; then
+    echo "ERROR: max_frames must be 0 or <= ${MAX_FRAME_CAP}: $MAX_FRAMES" >&2
+    exit 1
+fi
+
 if [[ "$STREAM_INDEX" != "auto" ]] && ! [[ "$STREAM_INDEX" =~ ^[0-9]+$ ]]; then
     echo "ERROR: stream_index must be 'auto' or a non-negative integer: $STREAM_INDEX" >&2
     exit 1
 fi
- 
+
 if ! [[ "$GRID_LAYOUT" =~ ^[1-9][0-9]*x[1-9][0-9]*$ ]]; then
     echo "ERROR: grid_layout must match NxM (e.g., 4x4): $GRID_LAYOUT" >&2
     exit 1
 fi
- 
+GRID_COLS="${GRID_LAYOUT%x*}"
+GRID_ROWS="${GRID_LAYOUT#*x}"
+GRID_CELLS=$((GRID_COLS * GRID_ROWS))
+if [[ "$GRID_COLS" -gt "$MAX_GRID_DIM" || "$GRID_ROWS" -gt "$MAX_GRID_DIM" || "$GRID_CELLS" -gt "$MAX_GRID_CELLS" ]]; then
+    echo "ERROR: grid_layout must be at most ${MAX_GRID_DIM}x${MAX_GRID_DIM} and <= ${MAX_GRID_CELLS} cells: $GRID_LAYOUT" >&2
+    exit 1
+fi
+
 if [[ -n "$START_TIME" ]] && ! is_time_value "$START_TIME"; then
     echo "ERROR: Invalid start_time format: $START_TIME" >&2
     exit 1
 fi
- 
+
 if [[ -n "$END_TIME" ]] && ! is_time_value "$END_TIME"; then
     echo "ERROR: Invalid end_time format: $END_TIME" >&2
     exit 1
 fi
- 
+START_SECONDS=0
+if [[ -n "$START_TIME" ]]; then
+    START_SECONDS=$(time_to_seconds "$START_TIME")
+fi
+END_SECONDS=""
+if [[ -n "$END_TIME" ]]; then
+    END_SECONDS=$(time_to_seconds "$END_TIME")
+fi
+if [[ -n "$END_SECONDS" && "$END_SECONDS" -le "$START_SECONDS" ]]; then
+    echo "ERROR: end_time must be greater than start_time" >&2
+    exit 1
+fi
+
 # Create output directory
 mkdir -p "$OUTPUT_DIR"
- 
+
 # Auto-detect video stream if not specified
 if [[ "$STREAM_INDEX" == "auto" ]]; then
     STREAM_INDEX=$(ffprobe -v error -show_streams -of json "$INPUT" 2>/dev/null | python3 -c "
@@ -87,7 +134,7 @@ else:
             break
 " 2>/dev/null || echo "0")
 fi
- 
+
 # Build the -map argument to select the correct video stream
 MAP_ARGS=("-map" "0:${STREAM_INDEX}")
 TIME_ARGS=()
@@ -97,12 +144,12 @@ fi
 if [[ -n "$END_TIME" ]]; then
     TIME_ARGS+=("-to" "$END_TIME")
 fi
- 
+
 # Get video info from the correct stream
 DURATION=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$INPUT" 2>/dev/null)
 RESOLUTION=$(ffprobe -v error -select_streams v:${STREAM_INDEX} -show_entries stream=width,height -of csv=p=0 "$INPUT" 2>/dev/null || echo "unknown")
 TOTAL_FRAMES=$(python3 -c "print(int(float('$DURATION') * float('$FPS')))" 2>/dev/null)
- 
+
 echo "=== Video Frame Extraction ==="
 echo "Input: $INPUT"
 echo "Duration: ${DURATION}s"
@@ -113,17 +160,20 @@ echo "Grid layout: $GRID_LAYOUT"
 echo "Estimated frames: $TOTAL_FRAMES"
 echo "Output: $OUTPUT_DIR"
 echo ""
- 
+
 # Build FFmpeg filter - resize to max 1280px wide, burn timestamp
 FILTER="fps=${FPS},scale='min(1280,iw)':-2,drawtext=text='%{pts\\:hms}':x=10:y=10:fontsize=28:fontcolor=white:borderw=2:bordercolor=black"
- 
+
 # Add frame limit if specified
-FRAME_LIMIT_ARGS=()
-if [[ "$MAX_FRAMES" -gt 0 ]]; then
-    FRAME_LIMIT_ARGS=("-frames:v" "$MAX_FRAMES")
-    echo "Frame limit: $MAX_FRAMES"
+EFFECTIVE_FRAME_LIMIT="$MAX_FRAMES"
+if [[ "$EFFECTIVE_FRAME_LIMIT" -eq 0 ]]; then
+    EFFECTIVE_FRAME_LIMIT="$MAX_FRAME_CAP"
 fi
- 
+FRAME_LIMIT_ARGS=("-frames:v" "$EFFECTIVE_FRAME_LIMIT")
+MONTAGE_LIMIT=$(((EFFECTIVE_FRAME_LIMIT + GRID_CELLS - 1) / GRID_CELLS))
+MONTAGE_LIMIT_ARGS=("-frames:v" "$MONTAGE_LIMIT")
+echo "Frame limit: $EFFECTIVE_FRAME_LIMIT"
+
 # Extract individual frames as JPG
 ffmpeg -i "$INPUT" \
     "${MAP_ARGS[@]}" \
@@ -133,30 +183,31 @@ ffmpeg -i "$INPUT" \
     "${FRAME_LIMIT_ARGS[@]}" \
     "${OUTPUT_DIR}/frame_%05d.jpg" \
     -y -loglevel warning 2>&1
- 
+
 EXTRACTED=$(ls "${OUTPUT_DIR}"/frame_*.jpg 2>/dev/null | wc -l | tr -d ' ')
 echo "Extracted: $EXTRACTED frames"
- 
+
 # Generate montage grids
 echo ""
 echo "=== Creating Montage Grids ==="
- 
+
 # Determine grid cell size based on orientation
 # Parse grid layout to determine if portrait-optimized
 GRID_CELL_WIDTH=640
 MONTAGE_FILTER="fps=${FPS},scale='min(${GRID_CELL_WIDTH},iw)':-2,drawtext=text='%{pts\\:hms}':x=5:y=5:fontsize=16:fontcolor=white:borderw=1:bordercolor=black,tile=${GRID_LAYOUT}"
- 
+
 ffmpeg -i "$INPUT" \
     "${MAP_ARGS[@]}" \
     "${TIME_ARGS[@]}" \
     -vf "$MONTAGE_FILTER" \
     -q:v 2 \
+    "${MONTAGE_LIMIT_ARGS[@]}" \
     "${OUTPUT_DIR}/grid_%03d.jpg" \
     -y -loglevel warning 2>&1
- 
+
 GRIDS=$(ls "${OUTPUT_DIR}"/grid_*.jpg 2>/dev/null | wc -l | tr -d ' ')
 echo "Created: $GRIDS montage grids (${GRID_LAYOUT})"
- 
+
 # Detect scene changes (key moments)
 echo ""
 echo "=== Scene Change Detection ==="
@@ -166,10 +217,10 @@ ffmpeg -i "$INPUT" \
     "${TIME_ARGS[@]}" \
     -vf "select='gt(scene,0.3)',showinfo" \
     -f null - 2>&1 | grep 'pts_time' | sed 's/.*pts_time:\([0-9.]*\).*/\1/' | grep '^[0-9]' > "$SCENE_FILE" || true
- 
+
 SCENE_COUNT=$(wc -l < "$SCENE_FILE" | tr -d ' ')
 echo "Detected: $SCENE_COUNT scene changes"
- 
+
 # Extract key frames at scene changes (high-res individual frames for detailed analysis)
 # Cap at 20 key frames to avoid excessive extraction
 if [[ "$SCENE_COUNT" -gt 0 ]]; then
@@ -194,7 +245,7 @@ if [[ "$SCENE_COUNT" -gt 0 ]]; then
     KEY_EXTRACTED=$(ls "${OUTPUT_DIR}"/key_frames/scene_*.jpg 2>/dev/null | wc -l | tr -d ' ')
     echo "Extracted: $KEY_EXTRACTED key frames at scene changes"
 fi
- 
+
 # Write metadata file
 cat > "${OUTPUT_DIR}/metadata.json" <<METAEOF
 {

--- a/scripts/video-info.sh
+++ b/scripts/video-info.sh
@@ -3,24 +3,47 @@
 # Usage: video-info.sh <input_video>
 # Outputs JSON with duration, resolution, codec, fps, audio info
 # Auto-detects the correct video stream (skips attached_pic/thumbnails)
-
+ 
 set -euo pipefail
-
+ 
 [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]] && export PATH="$HOME/bin:$PATH"
-
+ 
 INPUT="${1:?Usage: video-info.sh <input_video> [fps_override] [start_time] [end_time]}"
 FPS_OVERRIDE="${2:-}"      # e.g., "5" for 5fps, "0.2" for 1/5sec
 START_TIME="${3:-}"        # e.g., "00:00:10" or "10"
 END_TIME="${4:-}"          # e.g., "00:00:30" or "30"
-
+ 
+is_number() {
+    [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+}
+ 
+is_time_value() {
+    [[ "$1" =~ ^([0-9]+(:[0-9]{1,2}(:[0-9]{1,2})?)?)$ ]]
+}
+ 
 if [[ ! -f "$INPUT" ]]; then
     echo "ERROR: File not found: $INPUT" >&2
     exit 1
 fi
-
+ 
+if [[ -n "$FPS_OVERRIDE" ]] && ! is_number "$FPS_OVERRIDE"; then
+    echo "ERROR: fps_override must be numeric: $FPS_OVERRIDE" >&2
+    exit 1
+fi
+ 
+if [[ -n "$START_TIME" ]] && ! is_time_value "$START_TIME"; then
+    echo "ERROR: Invalid start_time format: $START_TIME" >&2
+    exit 1
+fi
+ 
+if [[ -n "$END_TIME" ]] && ! is_time_value "$END_TIME"; then
+    echo "ERROR: Invalid end_time format: $END_TIME" >&2
+    exit 1
+fi
+ 
 # Get full probe data
 PROBE=$(ffprobe -v error -show_format -show_streams -of json "$INPUT" 2>/dev/null)
-
+ 
 # Auto-detect the correct video stream index (skip attached_pic/thumbnail streams)
 # attached_pic streams have disposition.attached_pic=1 and are typically MJPEG
 VIDEO_STREAM_INDEX=$(echo "$PROBE" | python3 -c "

--- a/scripts/video-info.sh
+++ b/scripts/video-info.sh
@@ -3,47 +3,81 @@
 # Usage: video-info.sh <input_video>
 # Outputs JSON with duration, resolution, codec, fps, audio info
 # Auto-detects the correct video stream (skips attached_pic/thumbnails)
- 
+
 set -euo pipefail
- 
+
 [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]] && export PATH="$HOME/bin:$PATH"
- 
+
 INPUT="${1:?Usage: video-info.sh <input_video> [fps_override] [start_time] [end_time]}"
 FPS_OVERRIDE="${2:-}"      # e.g., "5" for 5fps, "0.2" for 1/5sec
 START_TIME="${3:-}"        # e.g., "00:00:10" or "10"
 END_TIME="${4:-}"          # e.g., "00:00:30" or "30"
- 
-is_number() {
-    [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]]
+
+MAX_FPS=120
+MAX_CUSTOM_FRAMES=1000
+
+is_positive_number() {
+    [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+    awk -v n="$1" 'BEGIN { exit !(n > 0) }'
 }
- 
+
+number_lte() {
+    awk -v n="$1" -v max="$2" 'BEGIN { exit !(n <= max) }'
+}
+
 is_time_value() {
-    [[ "$1" =~ ^([0-9]+(:[0-9]{1,2}(:[0-9]{1,2})?)?)$ ]]
+    [[ "$1" =~ ^[0-9]+$ || "$1" =~ ^[0-9]+:[0-5]?[0-9]$ || "$1" =~ ^[0-9]+:[0-5]?[0-9]:[0-5]?[0-9]$ ]]
 }
- 
+
+time_to_seconds() {
+    local value="$1"
+    local first second third
+    IFS=: read -r first second third <<< "$value"
+
+    if [[ -z "${second:-}" ]]; then
+        echo "$((10#$first))"
+    elif [[ -z "${third:-}" ]]; then
+        echo "$((10#$first * 60 + 10#$second))"
+    else
+        echo "$((10#$first * 3600 + 10#$second * 60 + 10#$third))"
+    fi
+}
+
 if [[ ! -f "$INPUT" ]]; then
     echo "ERROR: File not found: $INPUT" >&2
     exit 1
 fi
- 
-if [[ -n "$FPS_OVERRIDE" ]] && ! is_number "$FPS_OVERRIDE"; then
-    echo "ERROR: fps_override must be numeric: $FPS_OVERRIDE" >&2
+
+if [[ -n "$FPS_OVERRIDE" ]] && { ! is_positive_number "$FPS_OVERRIDE" || ! number_lte "$FPS_OVERRIDE" "$MAX_FPS"; }; then
+    echo "ERROR: fps_override must be > 0 and <= ${MAX_FPS}: $FPS_OVERRIDE" >&2
     exit 1
 fi
- 
+
 if [[ -n "$START_TIME" ]] && ! is_time_value "$START_TIME"; then
     echo "ERROR: Invalid start_time format: $START_TIME" >&2
     exit 1
 fi
- 
+
 if [[ -n "$END_TIME" ]] && ! is_time_value "$END_TIME"; then
     echo "ERROR: Invalid end_time format: $END_TIME" >&2
     exit 1
 fi
- 
+START_SECONDS=0
+if [[ -n "$START_TIME" ]]; then
+    START_SECONDS=$(time_to_seconds "$START_TIME")
+fi
+END_SECONDS=""
+if [[ -n "$END_TIME" ]]; then
+    END_SECONDS=$(time_to_seconds "$END_TIME")
+fi
+if [[ -n "$END_SECONDS" && "$END_SECONDS" -le "$START_SECONDS" ]]; then
+    echo "ERROR: end_time must be greater than start_time" >&2
+    exit 1
+fi
+
 # Get full probe data
 PROBE=$(ffprobe -v error -show_format -show_streams -of json "$INPUT" 2>/dev/null)
- 
+
 # Auto-detect the correct video stream index (skip attached_pic/thumbnail streams)
 # attached_pic streams have disposition.attached_pic=1 and are typically MJPEG
 VIDEO_STREAM_INDEX=$(echo "$PROBE" | python3 -c "
@@ -110,19 +144,16 @@ FILESIZE=$(echo "$PROBE" | python3 -c "import sys,json; d=json.load(sys.stdin); 
 
 # Calculate effective duration (respecting time range)
 EFFECTIVE_DURATION="$DURATION"
-if [[ -n "$START_TIME" && -n "$END_TIME" ]]; then
-    # Convert HH:MM:SS or seconds to seconds
-    start_sec=$(echo "$START_TIME" | awk -F: '{if(NF==3) print $1*3600+$2*60+$3; else if(NF==2) print $1*60+$2; else print $1}')
-    end_sec=$(echo "$END_TIME" | awk -F: '{if(NF==3) print $1*3600+$2*60+$3; else if(NF==2) print $1*60+$2; else print $1}')
-    EFFECTIVE_DURATION=$(python3 -c "print(float('$end_sec') - float('$start_sec'))" 2>/dev/null)
+if [[ -n "$END_SECONDS" ]]; then
+    EFFECTIVE_DURATION=$((END_SECONDS - START_SECONDS))
 elif [[ -n "$START_TIME" ]]; then
-    start_sec=$(echo "$START_TIME" | awk -F: '{if(NF==3) print $1*3600+$2*60+$3; else if(NF==2) print $1*60+$2; else print $1}')
-    EFFECTIVE_DURATION=$(python3 -c "print(float('$DURATION') - float('$start_sec'))" 2>/dev/null)
-elif [[ -n "$END_TIME" ]]; then
-    end_sec=$(echo "$END_TIME" | awk -F: '{if(NF==3) print $1*3600+$2*60+$3; else if(NF==2) print $1*60+$2; else print $1}')
-    EFFECTIVE_DURATION="$end_sec"
+    EFFECTIVE_DURATION=$(awk -v duration="$DURATION" -v start="$START_SECONDS" 'BEGIN { printf "%.6f\n", duration - start }')
 fi
-EFFECTIVE_INT=$(echo "$EFFECTIVE_DURATION" | cut -d. -f1)
+if ! awk -v duration="$EFFECTIVE_DURATION" 'BEGIN { exit !(duration > 0) }'; then
+    echo "ERROR: effective duration must be greater than zero" >&2
+    exit 1
+fi
+EFFECTIVE_INT=$(awk -v duration="$EFFECTIVE_DURATION" 'BEGIN { print int(duration) }')
 
 # Determine analysis tier (based on effective duration)
 if [[ "$EFFECTIVE_INT" -le 60 ]]; then
@@ -158,9 +189,11 @@ fi
 
 EXPECTED_FRAMES=$(python3 -c "print(int(float('$EFFECTIVE_DURATION') * float('$FPS_RATE')))" 2>/dev/null)
 
-# Cap at 200 frames to avoid excessive extraction
+# Cap expected frames to avoid excessive extraction
 MAX_FRAMES=0
-if [[ "$EXPECTED_FRAMES" -gt 200 ]]; then
+if [[ "$CUSTOM_FPS" == "true" && "$EXPECTED_FRAMES" -gt "$MAX_CUSTOM_FRAMES" ]]; then
+    MAX_FRAMES="$MAX_CUSTOM_FRAMES"
+elif [[ "$CUSTOM_FPS" == "false" && "$EXPECTED_FRAMES" -gt 200 ]]; then
     MAX_FRAMES=200
 elif [[ "$TIER" == "extended" && "$CUSTOM_FPS" == "false" && "$EXPECTED_FRAMES" -gt 60 ]]; then
     MAX_FRAMES=60


### PR DESCRIPTION
# Harden ffmpeg helper scripts with strict input validation and safe argument handling

## Motivation

- The scripts accepted user-controlled values that were passed into ffmpeg/ffprobe option paths.
- Argument construction relied on string assembly and shell word-splitting, which is fragile and can cause unexpected option parsing.
- We want safer, more predictable CLI invocation while preserving existing script behavior.

## Description

### `scripts/extract-frames.sh`

- Added input validation helpers:
  - `is_number` for numeric values (e.g. `FPS`).
  - `is_time_value` for time arguments (`START_TIME`, `END_TIME`).
- Added explicit validation for:
  - `FPS`
  - `MAX_FRAMES`
  - `STREAM_INDEX` (`auto` or non-negative integer)
  - `GRID_LAYOUT` (`NxM` pattern)
  - `START_TIME`
  - `END_TIME`
- Replaced string-based ffmpeg argument composition with array-based argv handling:
  - `MAP_ARGS`
  - `TIME_ARGS`
  - `FRAME_LIMIT_ARGS`
- Updated ffmpeg invocations to pass arrays via `"${ARRAY[@]}"` for predictable tokenization.

### `scripts/video-info.sh`

- Added matching input validation helpers and checks for:
  - `FPS_OVERRIDE`
  - `START_TIME`
  - `END_TIME`
- Ensures malformed overrides are rejected early and consistently with `extract-frames.sh`.

## Behavior / Compatibility

- Core workflow remains unchanged:
  - stream auto-detection
  - frame extraction
  - montage generation
  - scene-change detection
  - metadata output
- Scripts now fail fast on malformed input instead of passing invalid values deeper into ffmpeg/ffprobe.

## Testing

- `bash -n scripts/extract-frames.sh`
- `bash -n scripts/video-info.sh`
- Negative-path checks:
  - invalid fps override is rejected
  - invalid frame rate is rejected